### PR TITLE
Added link to aspnet insiders website in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,9 @@
 Public website
 --------------
 
+If you're just browsing, please visit : http://aspinsiders.github.io
+
+
+
 Please log issues in the Issues Tab above, and all changes must go through a Pull Request with another member.
 


### PR DESCRIPTION
Suggestion, please add a link to the aspnet insiders website from the readme.md file so that people who are just browsing can get to the content quickly.
